### PR TITLE
Fix : Change CustomerId Type Integer from int

### DIFF
--- a/src/main/java/com/erp/entity/Customer.java
+++ b/src/main/java/com/erp/entity/Customer.java
@@ -22,7 +22,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class Customer {
 	@Id
-	private int customerId;
+	private Integer customerId;
 	private String customerName;
 	private String customerGender;
 	private String customerTel;

--- a/src/main/java/com/erp/repository/ReservationRepository.java
+++ b/src/main/java/com/erp/repository/ReservationRepository.java
@@ -18,7 +18,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Intege
 
 	 //고객명 -> 고객 ID 조회
     @Query("SELECT c.customerId FROM Customer c WHERE c.customerName = :customerName")
-    int findCustomerIdByName(@Param("customerName") String customerName);
+    Integer findCustomerIdByName(@Param("customerName") String customerName);
 
     //서비스명 -> 서비스 코드 조회
     @Query("SELECT s.serviceCode FROM Service s WHERE s.serviceName = :serviceName")


### PR DESCRIPTION
ReservationRepository 의 findCustomerIdByName 메서드의 반환타입과
Customer 엔티티의 customerId 필드 데이터 타입을 int에서 Integer로 수정.

기본 데이터 타입인 int에는 null이 담길 수 없기 때문에 wrapper 타입인  Integer로 수정.
